### PR TITLE
Set AES default key

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.1.5
+version: 0.1.6
 home: https://github.com/Soluto/Kamus
 appVersion: 0.1.2.0
 keywords:

--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -12,7 +12,7 @@ Expand the name of the chart.
 {{ printf "\t\t\"ClientSecret\": \"%s\" " .Values.keyManagement.azureKeyVault.clientSecret }}
 {{ printf "} \n"}}
 {{- end -}}
-{{ if  eq .Values.keyManagement.provider "AES"}}
+{{ if  eq .Values.keyManagement.provider "AESKey"}}
 {{ printf "\"KeyManagement\": { \n\t\t\"AES\": { \"Key\": \"%s\" } }" .Values.keyManagement.AES.key }}
 {{- end -}}
 {{ printf "}" }}


### PR DESCRIPTION
Bad comparison leads to default installation without AES key - so each instance would generate its own key. We need better testing here :)