### PR TITLE
Allow pod annotations to be customized

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.1.10
+version: 0.1.11
 home: https://github.com/Soluto/Kamus
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
 appVersion: 0.2.4.0

--- a/charts/kamus/templates/deployment-decryptor.yaml
+++ b/charts/kamus/templates/deployment-decryptor.yaml
@@ -23,6 +23,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-decryptor.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.pod.annotations }}
+        {{- .Values.pod.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "kamus.name" . }}
         release: {{ .Release.Name }}

--- a/charts/kamus/templates/deployment-encryptor.yaml
+++ b/charts/kamus/templates/deployment-encryptor.yaml
@@ -23,6 +23,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-encryptor.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.pod.annotations }}
+        {{- .Values.pod.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "kamus.name" . }}
         component: encryptor

--- a/charts/kamus/values.yaml
+++ b/charts/kamus/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: soluto
   pullPolicy: IfNotPresent
 pod:
-  annotations:
+  annotations: {}
 service:
   type: ClusterIP
   annotations:

--- a/charts/kamus/values.yaml
+++ b/charts/kamus/values.yaml
@@ -10,6 +10,8 @@ image:
   version: 0.2.4.0
   repository: soluto
   pullPolicy: IfNotPresent
+pod:
+  annotations:
 service:
   type: ClusterIP
   annotations:


### PR DESCRIPTION
Current you are unable to set pod annotations with the helm chart, this would be handy so I can assign my IAM roles to them for kube2iam to work.