### PR TITLE
Added support for CRD conversion

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.3.1
+version: 0.4.0
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
-appVersion: 0.4.5.0
+appVersion: 0.5.1.0
 keywords:
   - gitops
   - secrets

--- a/charts/kamus/README.md
+++ b/charts/kamus/README.md
@@ -59,7 +59,7 @@ The chart can be customized using the following configurable parameters. Most se
 | `keyManagement.awsKms.region`                | AWS KMS region   | 
 | `keyManagement.awsKms.cmkPrefix`                | Prefix for the customer master keys that are created in the KMS  | 
 | `pod.annotations`                             | Set the annotations for Kamus's pods | 
-| `crdConersationEnabled`                       | The `CustomResourceWebhookConversion` is enabled (relevant for clusters bellow version 1.15.0 where it's enabled by default). Required for supporting conversations of CRDs objects from older to new version. |
+| `crdConersationEnabled`                       | Set to true if the `CustomResourceWebhookConversion` is enabled (relevant for clusters bellow version 1.15.0. Since Kubernetes 1.15.0 this feature is enabled by default). This is required for supporting conversations of CRDs objects from older to new version of the CRD. |
 
 Then use this command to install the chart:
 ```bash

--- a/charts/kamus/README.md
+++ b/charts/kamus/README.md
@@ -59,7 +59,7 @@ The chart can be customized using the following configurable parameters. Most se
 | `keyManagement.awsKms.region`                | AWS KMS region   | 
 | `keyManagement.awsKms.cmkPrefix`                | Prefix for the customer master keys that are created in the KMS  | 
 | `pod.annotations`                             | Set the annotations for Kamus's pods | 
-| `crdConersationEnabled`                       | Set to true if the `CustomResourceWebhookConversion` is enabled (relevant for clusters bellow version 1.15.0. Since Kubernetes 1.15.0 this feature is enabled by default). This is required for supporting conversations of CRDs objects from older to new version of the CRD. |
+| `crdConersationEnabled`                       | See bellow, relevant if running Kamus on a cluster version bellow 1.15.0 |
 
 Then use this command to install the chart:
 ```bash
@@ -67,3 +67,6 @@ helm install --name my-kamus soluto/kamus -f values.yaml
 ```
 
 Consult the [installtion guide](https://github.com/Soluto/kamus/blob/master/docs/install.md) for more details on how to configure Kamus for a production deployment.
+
+## Multiple KamusSecrets versions
+Kamus 0.5.0 introduced a new version of the KamusSecret CRD - `v1alpha2`. The chart and the API still support the older version (`v1alpha1`) using a [conversion webhook](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#webhook-conversion). This feature is enabled by default since Kubernetes version 1.15.0. If you run Kamus on an older version, and have the older version of the CRD you need to enable the relevant feature flag - `CustomResourceWebhookConversion`. See [Feature Gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) documentation for more details. 

--- a/charts/kamus/README.md
+++ b/charts/kamus/README.md
@@ -59,6 +59,7 @@ The chart can be customized using the following configurable parameters. Most se
 | `keyManagement.awsKms.region`                | AWS KMS region   | 
 | `keyManagement.awsKms.cmkPrefix`                | Prefix for the customer master keys that are created in the KMS  | 
 | `pod.annotations`                             | Set the annotations for Kamus's pods | 
+| `crdConersationEnabled`                       | The `CustomResourceWebhookConversion` is enabled (relevant for clusters bellow version 1.15.0 where it's enabled by default). Required for supporting conversations of CRDs objects from older to new version. |
 
 Then use this command to install the chart:
 ```bash

--- a/charts/kamus/templates/configmap-controller.yaml
+++ b/charts/kamus/templates/configmap-controller.yaml
@@ -4,3 +4,4 @@ metadata:
   name: {{ template "kamus.name" . }}-controller
 data:
 {{ include "common.configurations" . | indent 2 }}
+  TLS_CERT_FOLDER: /home/dotnet/app/tls

--- a/charts/kamus/templates/deployment-controller.yaml
+++ b/charts/kamus/templates/deployment-controller.yaml
@@ -23,6 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-controller.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/tls-secret: {{ include (print $.Template.BasePath "/kamussecret-crd.yaml") . | sha256sum }}
         {{- if .Values.pod.annotations }}
         {{- .Values.pod.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
@@ -40,6 +41,8 @@ spec:
           volumeMounts:
             - name: secret-volume
               mountPath: /home/dotnet/app/secrets
+            - name: tls-secret-volume
+              mountPath: /home/dotnet/app/tls
           livenessProbe:
             httpGet:
               path: /healthz
@@ -57,6 +60,9 @@ spec:
         - name: secret-volume
           secret:
             secretName: {{ template "kamus.name" . }}
+        - name: tls-secret-volume
+          secret:
+            secretName: {{ include "kamus.name" . }}-controller
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/kamus/templates/kamussecret-crd.yaml
+++ b/charts/kamus/templates/kamussecret-crd.yaml
@@ -1,10 +1,50 @@
+{{- $ca := genCA "kamus-ca" 3650 -}}
+{{- $altNames := list ( printf "%s-controller.%s" (include "kamus.name" .) .Release.Namespace ) ( printf "%s-controller.%s.svc" (include "kamus.name" .) .Release.Namespace ) -}}
+{{- $cn := include "kamus.name" . -}}
+{{- $cert := genSignedCert $cn nil $altNames 3650 $ca -}}
+{{- $kube115orHigher := semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion}}
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kamussecrets.soluto.com
 spec:
+  {{- if $kube115orHigher}}
+  preserveUnknownFields: false
+  {{- end }}
   group: soluto.com
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          data:
+            type: object
+            additionalProperties: true
+          serviceAccount: 
+            type: string
+          type:
+            type: string
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          data:
+            type: object
+            additionalProperties: true
+          stringData:
+            type: object
+            additionalProperties: true
+          serviceAccount: 
+            type: string
+          type:
+            type: string
   scope: Namespaced
   names:
     plural: kamussecrets
@@ -12,4 +52,23 @@ spec:
     kind: KamusSecret
     shortNames:
      - ks
-            
+  {{- if or $kube115orHigher .Values.crdConersationEnabled }}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ template "kamus.name" . }}-controller
+        path: /api/v1/conversion-webhook
+      caBundle: {{ b64enc $ca.Cert }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kamus.name" . }}-controller
+type: Opaque
+data:
+  certificate.crt: {{ b64enc $cert.Cert }}
+  privateKey.key: {{ b64enc $cert.Key }}

--- a/charts/kamus/templates/service-controller.yaml
+++ b/charts/kamus/templates/service-controller.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kamus.name" . }}-controller
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "kamus.name" . }}
+    component: controller
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 443
+      targetPort: 8888
+      protocol: TCP
+      name: kamus-controller
+
+  selector:
+    app: {{ template "kamus.name" . }}
+    component: controller
+    release: {{ .Release.Name }}

--- a/charts/kamus/values.yaml
+++ b/charts/kamus/values.yaml
@@ -7,7 +7,7 @@ airbag:
   repository: soluto
   tag: 0.8
 image:
-  version: 0.4.5.0
+  version: 0.5.1.0
   repository: soluto
   pullPolicy: IfNotPresent
 pod:


### PR DESCRIPTION
Add support for Soluto/kamus#246 - added support for the new CRD object version and conversion.

Inspirations and references:
 - A very good [blog post](https://medium.com/nuvo-group-tech/move-your-certs-to-helm-4f5f61338aca) about helm and certificates
- [Voyager Helm Chart](https://github.com/helm/charts/blob/cbd5e811a44c7bac6226b019f1d1810ef5ee45fa/stable/voyager/templates/apiregistration.yaml)