### PR TITLE
Modified awsKms automatic key rotation value to be piped to quote

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.4.0
+version: 0.4.1
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
 appVersion: 0.5.1.0

--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -40,7 +40,7 @@ KeyManagement__AwsKms__Region: {{ default "" .Values.keyManagement.awsKms.region
 KeyManagement__AwsKms__Key: {{ default "" .Values.keyManagement.awsKms.key }}
 KeyManagement__AwsKms__Secret: {{ default "" .Values.keyManagement.awsKms.secret }}
 KeyManagement__AwsKms__CmkPrefix: {{ default "" .Values.keyManagement.awsKms.cmkPrefix }}
-KeyManagement__AwsKms__AutomaticKeyRotation: {{ default "false" .Values.keyManagement.awsKms.enableAutomaticKeyRotation }}
+KeyManagement__AwsKms__AutomaticKeyRotation: {{ default "false" .Values.keyManagement.awsKms.enableAutomaticKeyRotation | quote }}
 {{ if .Values.keyManagement.awsKms.region }}
 AWS_REGION: {{ .Values.keyManagement.awsKms.region }}
 {{ end }}


### PR DESCRIPTION
Currently, if you try to deploy the Kamus helm chart, configured for awsKms, it will throw the following error:

```Error: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found t, error found in #10 byte of ...|otation":true,"KeyMa|..., bigger context ...|1","KeyManagement__AwsKms__AutomaticKeyRotation":true,"KeyManagement__AwsKms__CmkPrefix":"test","Key|...```

This is because the boolean value for "KeyManagement__AwsKms__AutomaticKeyRotation" needs to be piped to "quote".  You can reproduce the error by running:

```helm upgrade --install --set keyManagement.provider=awsKms,keyManagement.awsKms.region=us-east-1,keyManagement.awsKms.key=test,keyManagement.awsKms.secret=test,keyManagement.awsKms.cmkPrefix=test,keyManagement.awsKms.enableAutomaticKeyRotation=true kamus ./charts/kamus```

(Using helm v3.0.0-beta.3)

---
This fixes that by simply adding | quote to the value. :)  Also I love this project.