### PR TITLE
Added support for useKeyDerivation with the AES provider

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.4.8
+version: 0.4.9
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
 appVersion: 0.6.7.0

--- a/charts/kamus/README.md
+++ b/charts/kamus/README.md
@@ -45,6 +45,7 @@ The chart can be customized using the following configurable parameters. Most se
 | `keyManagement.provider`                        | The KMS provider (AESKey/AzureKeyVault/GoogleKms/AwsKms)  | AES
 | `keyManagement.secretName`                        | Use pre-created secret for keyManagement |
 | `keyManagement.AES.key`                         | The encryption key used by the AES provider, *ovveride for production deployments*. This value *must* kept secret            | `rWnWbaFutavdoeqUiVYMNJGvmjQh31qaIej/vAxJ9G0=`
+| `keyManagement.AES.useKeyDerivation`            | Should the AES key be derived from the service account name            | false
 | `keyManagement.azureKeyVault.clientId`           | A client ID for a valid Azure Active Directory that has permissions to access the requested key vault |    
 | `keyManagement.azureKeyVault.clientSecret`          | A client secret for a valid Azure Active Directory that has permissions to access the requested key vault. This value *must* kept secret |   
 | `keyManagement.azureKeyVault.keyVaultName`          | The name of the KeyVault to use | 

--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -20,14 +20,14 @@ Expand the name of the chart.
 
 {{- define "common.configurations" -}}
 KeyManagement__Provider: {{ .Values.keyManagement.provider }}
-{{ if .Values.keyManagement.azureKeyVault }}
+{{- if .Values.keyManagement.azureKeyVault }}
 KeyManagement__KeyVault__Name: {{ .Values.keyManagement.azureKeyVault.keyVaultName }}
 KeyManagement__KeyVault__KeyType: {{ default "RSA-HSM" .Values.keyManagement.azureKeyVault.keyType }}
 KeyManagement__KeyVault__KeyLength: {{ default "2048" .Values.keyManagement.azureKeyVault.keySize | quote }}
 KeyManagement__KeyVault__MaximumDataLength: {{ default "214" .Values.keyManagement.azureKeyVault.maximumDataLength | quote }}
 ActiveDirectory__ClientId: {{ .Values.keyManagement.azureKeyVault.clientId }}
 {{ end }}
-{{ if .Values.keyManagement.googleKms }}
+{{- if .Values.keyManagement.googleKms }}
 KeyManagement__GoogleKms__Location: {{ .Values.keyManagement.googleKms.location }}
 KeyManagement__GoogleKms__KeyRingName: {{ .Values.keyManagement.googleKms.keyRing }}
 KeyManagement__GoogleKms__ProtectionLevel: {{ default "HSM" .Values.keyManagement.googleKms.protectionLevel }}
@@ -35,14 +35,17 @@ KeyManagement__GoogleKms__RotationPeriod: {{ default "" .Values.keyManagement.go
 KeyManagement__GoogleKms__ProjectId: {{ default "" .Values.keyManagement.googleKms.projectId }}
 GOOGLE_APPLICATION_CREDENTIALS: "/home/dotnet/app/secrets/googlecloudcredentials.json"
 {{ end }}
-{{ if .Values.keyManagement.awsKms }}
+{{- if .Values.keyManagement.awsKms }}
 KeyManagement__AwsKms__Region: {{ default "" .Values.keyManagement.awsKms.region }}
 KeyManagement__AwsKms__Key: {{ default "" .Values.keyManagement.awsKms.key }}
 KeyManagement__AwsKms__Secret: {{ default "" .Values.keyManagement.awsKms.secret }}
 KeyManagement__AwsKms__CmkPrefix: {{ default "" .Values.keyManagement.awsKms.cmkPrefix }}
 KeyManagement__AwsKms__AutomaticKeyRotation: {{ default "false" .Values.keyManagement.awsKms.enableAutomaticKeyRotation | quote }}
-{{ if .Values.keyManagement.awsKms.region }}
+{{- if .Values.keyManagement.awsKms.region }}
 AWS_REGION: {{ .Values.keyManagement.awsKms.region }}
 {{ end }}
 {{ end }}
+{{- if .Values.keyManagement.AES }}
+KeyManagement__AES__UseKeyDeriviation: {{ default false .Values.keyManagement.AES.useKeyDerivation }}
+{{- end -}}
 {{- end -}}}}

--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -46,6 +46,6 @@ AWS_REGION: {{ .Values.keyManagement.awsKms.region }}
 {{ end }}
 {{ end }}
 {{- if .Values.keyManagement.AES }}
-KeyManagement__AES__UseKeyDeriviation: {{ default false .Values.keyManagement.AES.useKeyDerivation }}
+KeyManagement__AES__UseKeyDeriviation: {{ default "false" .Values.keyManagement.AES.useKeyDerivation | quote }}
 {{- end -}}
 {{- end -}}}}

--- a/charts/kamus/values.yaml
+++ b/charts/kamus/values.yaml
@@ -33,5 +33,6 @@ keyManagement:
   provider: AESKey
   AES:
     key: rWnWbaFutavdoeqUiVYMNJGvmjQh31qaIej/vAxJ9G0=
+    useKeyDerivation: false
 encryptor:
   automountServiceAccountToken: false


### PR DESCRIPTION
Created to address #39 . This just adds the useKeyDerivation option to the AES config and sets the key in the same way as the other configuration options (which I assume is the .NET configuration syntax).

As part of this I tidied up the newlines in the configmap, happy to remove that if required. 