### PR TITLE
fix: issue #36 googleKms.rotationPeriod converted to int but it's expected to be a string

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.4.17
+version: 0.4.18
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
 appVersion: 0.8.0.0

--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -31,7 +31,7 @@ ActiveDirectory__ClientId: {{ .Values.keyManagement.azureKeyVault.clientId }}
 KeyManagement__GoogleKms__Location: {{ .Values.keyManagement.googleKms.location }}
 KeyManagement__GoogleKms__KeyRingName: {{ .Values.keyManagement.googleKms.keyRing }}
 KeyManagement__GoogleKms__ProtectionLevel: {{ default "HSM" .Values.keyManagement.googleKms.protectionLevel }}
-KeyManagement__GoogleKms__RotationPeriod: {{ default "" .Values.keyManagement.googleKms.rotationPeriod }}
+KeyManagement__GoogleKms__RotationPeriod: {{ default "" .Values.keyManagement.googleKms.rotationPeriod | quote }}
 KeyManagement__GoogleKms__ProjectId: {{ default "" .Values.keyManagement.googleKms.projectId }}
 GOOGLE_APPLICATION_CREDENTIALS: "/home/dotnet/app/secrets/googlecloudcredentials.json"
 {{ end }}


### PR DESCRIPTION
this should fixed the issue when you omit `KeyManagement__GoogleKms__RotationPeriod` and chart install fails