### PR TITLE
Adding the `propagateAnnotations` to the CRD

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.4.19
+version: 0.5.0
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
-appVersion: 0.8.0.0
+appVersion: 0.8.1.0
 keywords:
   - gitops
   - secrets

--- a/charts/kamus/README.md
+++ b/charts/kamus/README.md
@@ -25,7 +25,7 @@ The chart can be customized using the following configurable parameters. Most se
 | `airbag.authority`                             | The authority issueing the token | 
 | `airbag.audience`                              | The audience used to validate the token (`aud` claim) |
 | `airbag.issuer`                                | The issuer used to validate the token (`iss` claim) |              
-| `image.version`                                | The image of Kamus to pull. Image naming convention is `kamus:encryption-{version}` and `kamus:encryption-{version}`                        | `0.8.0.0`     
+| `image.version`                                | The image of Kamus to pull. Image naming convention is `kamus:encryption-{version}` and `kamus:encryption-{version}`                        | `0.8.1.0`
 | `image.repository`                              | The docker repository to pull the images from                                                     | `soluto`                                        
 | `image.pullPolicy`                              | Kamus containers pull policy                                          | `IfNotPresent`                                                            
 | `service.type`                                 | The type of the service (careful, values other than `ClusterIp` expose the decryptor to the internet)                         | `ClusterIp`   

--- a/charts/kamus/templates/kamussecret-crd.yaml
+++ b/charts/kamus/templates/kamussecret-crd.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
           type:
             type: string
-          copyAnnotations:
+          annotationsInheritance:
             type: boolean
             default: false
     {{- end }}

--- a/charts/kamus/templates/kamussecret-crd.yaml
+++ b/charts/kamus/templates/kamussecret-crd.yaml
@@ -48,7 +48,7 @@ spec:
             type: string
           type:
             type: string
-          annotationsInheritance:
+          propagateAnnotations:
             type: boolean
             default: false
     {{- end }}

--- a/charts/kamus/templates/kamussecret-crd.yaml
+++ b/charts/kamus/templates/kamussecret-crd.yaml
@@ -48,6 +48,9 @@ spec:
             type: string
           type:
             type: string
+          copyAnnotations:
+            type: boolean
+            default: false
     {{- end }}
   scope: Namespaced
   names:

--- a/charts/kamus/templates/kamussecret-crd.yaml
+++ b/charts/kamus/templates/kamussecret-crd.yaml
@@ -50,7 +50,6 @@ spec:
             type: string
           propagateAnnotations:
             type: boolean
-            default: false
     {{- end }}
   scope: Namespaced
   names:

--- a/charts/kamus/values.yaml
+++ b/charts/kamus/values.yaml
@@ -7,7 +7,7 @@ airbag:
   repository: soluto
   tag: 0.8
 image:
-  version: 0.8.0.0
+  version: 0.8.1.0
   repository: soluto
   pullPolicy: IfNotPresent
 pod:


### PR DESCRIPTION
The `propagateAnnotations` will be the option to opt-in to copy annotations from `KamusSecret` to `Secret`

Soluto/Kamus#596