### PR TITLE
Bump ingress API version due to deprecation in k8s 1.16

### DIFF
--- a/charts/kamus/Chart.yaml
+++ b/charts/kamus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: An open source, git-ops, zero-trust secrets encryption and decryption solution for Kubernetes applications
 name: kamus
-version: 0.5.0
+version: 0.5.1
 home: https://kamus.soluto.io
 icon: https://raw.githubusercontent.com/Soluto/kamus/master/images/logo.png
 appVersion: 0.8.1.0

--- a/charts/kamus/templates/ingress.yaml
+++ b/charts/kamus/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "kamus.name" . }}

--- a/charts/kamus/templates/ingress.yaml
+++ b/charts/kamus/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kamus.name" . }}


### PR DESCRIPTION
K8s 1.16 is deprecating the ingress object API: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
The new ingress API version **networking.k8s.io/v1beta1** is available since k8s 1.14
This PR is in order for teams migrating to k8s >=1.16 be still able to use Kamus from the upstream chart repository.