### PR TITLE
Adding Helm namespace support

### DIFF
--- a/charts/kamus/templates/_helpers.tpl
+++ b/charts/kamus/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kamus.namespace" -}}
+{{- default "default" .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "appsettings.secrets.json" }}
 {{ printf "{" }}
 {{ if eq .Values.keyManagement.provider "AzureKeyVault"}}

--- a/charts/kamus/templates/autoscaling-decryptor.yaml
+++ b/charts/kamus/templates/autoscaling-decryptor.yaml
@@ -2,6 +2,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "kamus.name" . }}-decryptor
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: decryptor

--- a/charts/kamus/templates/autoscaling-encryptor.yaml
+++ b/charts/kamus/templates/autoscaling-encryptor.yaml
@@ -2,6 +2,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "kamus.name" . }}-encryptor
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: encryptor

--- a/charts/kamus/templates/configmap-controller.yaml
+++ b/charts/kamus/templates/configmap-controller.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kamus.name" . }}-controller
+  namespace: {{ template "kamus.namespace" . }}
 data:
 {{ include "common.configurations" . | indent 2 }}
   Controller__ReconciliationIntervalInSeconds: {{ .Values.controller.reconciliationIntervalInSeconds | quote }}

--- a/charts/kamus/templates/configmap-decryptor.yaml
+++ b/charts/kamus/templates/configmap-decryptor.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kamus.name" . }}-decryptor
+  namespace: {{ template "kamus.namespace" . }}
 data:
 {{ include "common.configurations" . | indent 2 }}

--- a/charts/kamus/templates/configmap-encryptor.yaml
+++ b/charts/kamus/templates/configmap-encryptor.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kamus.name" . }}-encryptor
+  namespace: {{ template "kamus.namespace" . }}
 data:
 {{ include "common.configurations" . | indent 2 }}

--- a/charts/kamus/templates/deployment-controller.yaml
+++ b/charts/kamus/templates/deployment-controller.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kamus.name" . }}-controller
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: controller

--- a/charts/kamus/templates/deployment-decryptor.yaml
+++ b/charts/kamus/templates/deployment-decryptor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kamus.name" . }}-decryptor
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: decryptor

--- a/charts/kamus/templates/deployment-encryptor.yaml
+++ b/charts/kamus/templates/deployment-encryptor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kamus.name" . }}-encryptor
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: encryptor

--- a/charts/kamus/templates/ingress.yaml
+++ b/charts/kamus/templates/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kamus.name" . }}
+  namespace: {{ template "kamus.namespace" . }}
   labels:
     app: {{ template "kamus.name" . }}
     component: encryptor

--- a/charts/kamus/templates/secret.yaml
+++ b/charts/kamus/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kamus.name" . }}
+  namespace: {{ template "kamus.namespace" . }}
 type: Opaque
 data:
   appsettings.secrets.json: {{ include "appsettings.secrets.json"  . | b64enc}}

--- a/charts/kamus/templates/service-controller.yaml
+++ b/charts/kamus/templates/service-controller.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kamus.name" . }}-controller
+  namespace: {{ template "kamus.namespace" . }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/kamus/templates/service-decryptor.yaml
+++ b/charts/kamus/templates/service-decryptor.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kamus.name" . }}-decryptor
+  namespace: {{ template "kamus.namespace" . }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/kamus/templates/service-encryptor.yaml
+++ b/charts/kamus/templates/service-encryptor.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kamus.name" . }}-encryptor
-
+  namespace: {{ template "kamus.namespace" . }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/kamus/templates/serviceaccount-controller.yaml
+++ b/charts/kamus/templates/serviceaccount-controller.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kamus.name" . }}-controller
+  namespace: {{ template "kamus.namespace" . }}

--- a/charts/kamus/templates/serviceaccount.yaml
+++ b/charts/kamus/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kamus.name" . }}
+  namespace: {{ template "kamus.namespace" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
First, this solution is awesome. Congratulations Soluto team.

**Problem:** Kamus Helm chart doesn't have support custom namespace.

**Resolution:** Adding namespace metadata with Helm launch variable with this is able to run Helm with "--namespace" parameter and deploy Kamus in custom namespace.

_Helm reference_: https://helm.sh/docs/chart_template_guide/builtin_objects/